### PR TITLE
Fix: Date search error on related records

### DIFF
--- a/force-app/main/v2/filter/classes/FilterDataService.cls
+++ b/force-app/main/v2/filter/classes/FilterDataService.cls
@@ -128,9 +128,6 @@ public with sharing class FilterDataService extends DataService {
     if (String.isNotBlank(conditions)) {
       query += ' WHERE ' + conditions;
     }
-
-    System.debug(query);
-
     List<Id> recordIds = performQuery(query);
 
     return new Result(recordIds);

--- a/force-app/main/v2/shared/classes/Describer.cls
+++ b/force-app/main/v2/shared/classes/Describer.cls
@@ -158,19 +158,23 @@ public with sharing class Describer {
         reducedFieldPath,
         relationshipNames
       );
-    } else if (
-      dfr.getType() == Schema.DisplayType.DATE ||
-      dfr.getType() == Schema.DisplayType.DATETIME
-    ) {
-      FieldInfo field = new FieldInfo(dsor, dfr, fieldApiName);
-      if (preferedObjectApiName == 'relative') {
+    } else {
+      relationshipNames.add(dfr.getName());
+      FieldInfo field = new FieldInfo(
+        dsor,
+        dfr,
+        String.join(relationshipNames, '.')
+      );
+
+      if (
+        (dfr.getType() == Schema.DisplayType.DATE ||
+        dfr.getType() == Schema.DisplayType.DATETIME) &&
+        preferedObjectApiName == 'relative'
+      ) {
         field.fieldPath = field.fieldPath?.split(':')[0];
         field.isRelative = true;
       }
       return field;
-    } else {
-      relationshipNames.add(dfr.getName());
-      return new FieldInfo(dsor, dfr, String.join(relationshipNames, '.'));
     }
   }
 


### PR DESCRIPTION
## Issue
Searching EventRelation with `EventId.ActivityDate` throws:
```
[No such column 'ActivityDate' on entity 'EventRelation'...]
```

## Root Cause
`Describer.cls` incorrectly handled relationship field paths for DATE/DATETIME fields, causing malformed SOQL queries.

## Changes
- **Describer.cls**: Fixed relationship name handling in `describeField` method
- **FilterDataService.cls**: Removed debug statement

## Files Modified
- `force-app/main/v2/shared/classes/Describer.cls`
- `force-app/main/v2/filter/classes/FilterDataService.cls`

## Testing
- EventRelation date search now works correctly
- No impact on other related record searches
